### PR TITLE
Port across commit sum

### DIFF
--- a/include/secp256k1_rangeproof.h
+++ b/include/secp256k1_rangeproof.h
@@ -100,6 +100,24 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_pedersen_blind_sum(
   size_t npositive
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
+/** Computes the sum of multiple positive and negative pedersen commitments
+ * Returns 1: sum successfully computed.
+ * In:     ctx:        pointer to a context object, initialized for Pedersen commitment (cannot be NULL)
+ *         commits:    pointer to array of pointers to the commitments. (cannot be NULL if pcnt is non-zero)
+ *         pcnt:       number of commitments pointed to by commits.
+ *         ncommits:   pointer to array of pointers to the negative commitments. (cannot be NULL if ncnt is non-zero)
+ *         ncnt:       number of commitments pointed to by ncommits.
+ *  Out:   commit_out: pointer to the commitment (cannot be NULL)
+ */
+SECP256K1_WARN_UNUSED_RESULT int secp256k1_pedersen_commit_sum(
+  const secp256k1_context* ctx,
+  secp256k1_pedersen_commitment *commit_out,
+  const secp256k1_pedersen_commitment * const* commits,
+  size_t pcnt,
+  const secp256k1_pedersen_commitment * const* ncommits,
+  size_t ncnt
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5);
+
 /** Verify a tally of pedersen commitments
  * Returns 1: commitments successfully sum to zero.
  *         0: Commitments do not sum to zero or other error.

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -14,6 +14,7 @@
 #ifdef USE_ECMULT_STATIC_PRECOMPUTATION
 #include "ecmult_static_context.h"
 #endif
+#include <string.h>
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context *ctx) {
     ctx->prec = NULL;
 }

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -135,25 +135,21 @@ int secp256k1_pedersen_commit_sum(const secp256k1_context* ctx, secp256k1_peders
     (void) ctx;
     secp256k1_gej_set_infinity(&accj);
     for (i = 0; i < ncnt; i++) {
-        if (!secp256k1_eckey_pubkey_parse(&add, ncommits[i], 33)) {
-            return 0;
-        }
+        secp256k1_pedersen_commitment_load(&add, ncommits[i]);
         secp256k1_gej_add_ge_var(&accj, &accj, &add, NULL);
     }
     secp256k1_gej_neg(&accj, &accj);
     for (i = 0; i < pcnt; i++) {
-        if (!secp256k1_eckey_pubkey_parse(&add, commits[i], 33)) {
-            return 0;
-        }
+        secp256k1_pedersen_commitment_load(&add, commits[i]);
         secp256k1_gej_add_ge_var(&accj, &accj, &add, NULL);
     }
     if (!secp256k1_gej_is_infinity(&accj)) {
         size_t sz = 33;
         secp256k1_ge acc;
         secp256k1_ge_set_gej(&acc, &accj);
-        ret = secp256k1_eckey_pubkey_serialize(&acc, commit_out, &sz, 1);
+        secp256k1_pedersen_commitment_save(commit_out, &acc);
+        ret = 1;
     }
-
     return ret;
 }
 

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -121,6 +121,42 @@ int secp256k1_pedersen_blind_sum(const secp256k1_context* ctx, unsigned char *bl
     return 1;
 }
 
+/* Takes two list of 33-byte commitments and sums the first set, subtracts the second and returns the resulting commitment. */
+int secp256k1_pedersen_commit_sum(const secp256k1_context* ctx, secp256k1_pedersen_commitment *commit_out,
+ const secp256k1_pedersen_commitment * const* commits, size_t pcnt, const secp256k1_pedersen_commitment * const* ncommits, size_t ncnt) {
+    secp256k1_gej accj;
+    secp256k1_ge add;
+    size_t i;
+    int ret = 0;
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(!pcnt || (commits != NULL));
+    ARG_CHECK(!ncnt || (ncommits != NULL));
+    ARG_CHECK(commit_out != NULL);
+    (void) ctx;
+    secp256k1_gej_set_infinity(&accj);
+    for (i = 0; i < ncnt; i++) {
+        if (!secp256k1_eckey_pubkey_parse(&add, ncommits[i], 33)) {
+            return 0;
+        }
+        secp256k1_gej_add_ge_var(&accj, &accj, &add, NULL);
+    }
+    secp256k1_gej_neg(&accj, &accj);
+    for (i = 0; i < pcnt; i++) {
+        if (!secp256k1_eckey_pubkey_parse(&add, commits[i], 33)) {
+            return 0;
+        }
+        secp256k1_gej_add_ge_var(&accj, &accj, &add, NULL);
+    }
+    if (!secp256k1_gej_is_infinity(&accj)) {
+        size_t sz = 33;
+        secp256k1_ge acc;
+        secp256k1_ge_set_gej(&acc, &accj);
+        ret = secp256k1_eckey_pubkey_serialize(&acc, commit_out, &sz, 1);
+    }
+
+    return ret;
+}
+
 /* Takes two lists of commitments and sums the first set and subtracts the second and verifies that they sum to excess. */
 int secp256k1_pedersen_verify_tally(const secp256k1_context* ctx, const secp256k1_pedersen_commitment * const* commits, size_t pcnt, const secp256k1_pedersen_commitment * const* ncommits, size_t ncnt) {
     secp256k1_gej accj;

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -144,7 +144,6 @@ int secp256k1_pedersen_commit_sum(const secp256k1_context* ctx, secp256k1_peders
         secp256k1_gej_add_ge_var(&accj, &accj, &add, NULL);
     }
     if (!secp256k1_gej_is_infinity(&accj)) {
-        size_t sz = 33;
         secp256k1_ge acc;
         secp256k1_ge_set_gej(&acc, &accj);
         secp256k1_pedersen_commitment_save(commit_out, &acc);


### PR DESCRIPTION
Ported across and cleaned up `secp256k1_pedersen_commit_sum ` from Grin.
This *appears* to work as expected when used via `rust-secp256k1-zkp` but somebody more familiar with this code should review this (I am not confident I know what I am doing here...)
