### PR TITLE
add ability to get public key from a pedersen commitment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ config.status
 libtool
 .deps/
 .dirstamp
+.idea/
 *.lo
 *.o
 *~

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -110,6 +110,25 @@ int secp256k1_pedersen_commit(const secp256k1_context* ctx, secp256k1_pedersen_c
     return ret;
 }
 
+/* Get the public key of a pedersen commitment */ 
+int secp256k1_pedersen_commitment_to_pubkey(const secp256k1_context* ctx, secp256k1_pubkey* pubkey, const secp256k1_pedersen_commitment* commit) {
+     secp256k1_ge Q;
+     VERIFY_CHECK(ctx != NULL);
+     ARG_CHECK(pubkey != NULL);
+     memset(pubkey, 0, sizeof(*pubkey));
+     ARG_CHECK(commit != NULL);
+
+     secp256k1_fe fe;
+     secp256k1_fe_set_b32(&fe, &commit->data[1]);
+     secp256k1_ge_set_xquad(&Q, &fe);
+     if (commit->data[0] & 1) {
+         secp256k1_ge_neg(&Q, &Q);
+     }
+     secp256k1_pubkey_save(pubkey, &Q);
+     secp256k1_ge_clear(&Q);
+     return 1;
+ }
+
 /** Takes a list of n pointers to 32 byte blinding values, the first negs of which are treated with positive sign and the rest
  *  negative, then calculates an additional blinding value that adds to zero.
  */


### PR DESCRIPTION
To complete the TODO item in repo `rust-secp256k1-zkp`: need an API in secp to convert commitments to public keys safely. a commitment is prefixed 08/09 and public keys are prefixed 02/03.

A new function `secp256k1_pedersen_commitment_to_pubkey` is added.