### PR TITLE
fix types for secp256k1_scalar_chacha20()

### DIFF
--- a/src/scalar_low_impl.h
+++ b/src/scalar_low_impl.h
@@ -112,7 +112,7 @@ SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const
     return *a == *b;
 }
 
-SECP256K1_INLINE static void secp256k1_scalar_chacha20(secp256k1_scalar *r1, secp256k1_scalar *r2, const unsigned char *seed, size_t n) {
+SECP256K1_INLINE static void secp256k1_scalar_chacha20(secp256k1_scalar *r1, secp256k1_scalar *r2, const unsigned char *seed, uint64_t n) {
     *r1 = (seed[0] + n) % EXHAUSTIVE_TEST_ORDER;
     *r2 = (seed[1] + n) % EXHAUSTIVE_TEST_ORDER;
 }


### PR DESCRIPTION
Same issue as `secp256k1_bulletproof_rangeproof_rewind()` earlier.

`size_t` -> `uint64_t`