### PR TITLE
Aggsig compatibility with BIP-schnorr

### DIFF
--- a/include/secp256k1_aggsig.h
+++ b/include/secp256k1_aggsig.h
@@ -107,9 +107,9 @@ SECP256K1_API int secp256k1_aggsig_export_secnonce_single(
  *           pubnonce_total: If non-NULL, allow this signature to be included in combined sig
  *               in all cases by negating secnonce32 if the public nonce total has jacobi symbol 
  *               -1. secnonce32 must also be provided
+ *           pubkey_for_e: If this is non-NULL, encode this value in e
  *           seed: a 32-byte seed to use for the nonce-generating RNG (cannot be NULL)
  */
-
 SECP256K1_API int secp256k1_aggsig_sign_single(
     const secp256k1_context* ctx,
     unsigned char *sig64,
@@ -118,8 +118,9 @@ SECP256K1_API int secp256k1_aggsig_sign_single(
     const unsigned char* secnonce32,
     const secp256k1_pubkey *pubnonce_for_e,
     const secp256k1_pubkey* pubnonce_total,
+    const secp256k1_pubkey* pubkey_for_e,
     const unsigned char* seed)
-SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(8) SECP256K1_WARN_UNUSED_RESULT;
+SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(9) SECP256K1_WARN_UNUSED_RESULT;
 
 /** Generate a single signature part in an aggregated signature
  *
@@ -185,6 +186,7 @@ SECP256K1_API int secp256k1_aggsig_add_signatures_single(
  *           msg32: the message to verify (cannot be NULL)
  *           pubnonce: if non-NULL, override the public nonce used to calculate e
  *           pubkey: the public key (cannot be NULL)
+ *           pubkey_total: if non-NULL, encode this value in e
  *           is_partial: whether to ignore the jacobi symbol of the combined R, set this to 1
  *               to verify partial signatures that may have had their secret nonces negated
  */
@@ -194,6 +196,7 @@ SECP256K1_API int secp256k1_aggsig_verify_single(
     const unsigned char *msg32,
     const secp256k1_pubkey *pubnonce,
     const secp256k1_pubkey *pubkey,
+    const secp256k1_pubkey *pubkey_total,
     const int is_partial)
 SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5) SECP256K1_WARN_UNUSED_RESULT;
 

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -33,7 +33,7 @@ struct secp256k1_aggsig_context_struct {
 };
 
 /* Compute sighash for a single-signer */
-static int secp256k1_compute_sighash_single(const secp256k1_context *ctx, secp256k1_scalar *r, const secp256k1_pubkey *pubkey, const unsigned char *msghash32) {
+static int secp256k1_compute_sighash_single(const secp256k1_context *ctx, secp256k1_scalar *r, const secp256k1_pubkey *pubnonce, const secp256k1_pubkey *pubkey, const unsigned char *msghash32) {
     unsigned char output[32];
     unsigned char buf[33];
     size_t buflen = sizeof(buf);
@@ -43,10 +43,19 @@ static int secp256k1_compute_sighash_single(const secp256k1_context *ctx, secp25
     secp256k1_sha256_initialize(&hasher);
 
     /* Encode public nonce */
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, buf, &buflen, pubkey, SECP256K1_EC_COMPRESSED));
+    CHECK(secp256k1_ec_pubkey_serialize(ctx, buf, &buflen, pubnonce, SECP256K1_EC_COMPRESSED));
 
-    /* Remove the first encoding element, as it may differ depending on how we got here */
-    secp256k1_sha256_write(&hasher, buf+1, sizeof(buf-1));
+    /* Encode public key, if present */
+    if (pubkey != NULL) {
+        /* Grin T3: using a public key indicates we are past the hard fork point, so we can use the full 32 bytes of the public nonce */
+        secp256k1_sha256_write(&hasher, buf+1, 32);
+        CHECK(secp256k1_ec_pubkey_serialize(ctx, buf, &buflen, pubkey, SECP256K1_EC_COMPRESSED));
+        secp256k1_sha256_write(&hasher, buf+1, 32);
+    }
+    else {
+        /* Remove the first encoding element, as it may differ depending on how we got here */
+        secp256k1_sha256_write(&hasher, buf+1, sizeof(buf-1));
+    }
 
     /* Encode message */
     secp256k1_sha256_write(&hasher, msghash32, 32);
@@ -187,6 +196,7 @@ int secp256k1_aggsig_sign_single(const secp256k1_context* ctx,
     const unsigned char* secnonce32,
     const secp256k1_pubkey* pubnonce_for_e,
     const secp256k1_pubkey* pubnonce_total,
+    const secp256k1_pubkey* pubkey_for_e,
     const unsigned char* seed){
 
     secp256k1_scalar sighash;
@@ -242,10 +252,10 @@ int secp256k1_aggsig_sign_single(const secp256k1_context* ctx,
 
     /* compute signature hash (in the simple case just message+pubnonce) */
     if (pubnonce_for_e != NULL) {
-        secp256k1_compute_sighash_single(ctx, &sighash, pubnonce_for_e, msg32);
+        secp256k1_compute_sighash_single(ctx, &sighash, pubnonce_for_e, pubkey_for_e, msg32);
     } else {
         secp256k1_pubkey_save(&pub_tmp, &tmp_ge);
-        secp256k1_compute_sighash_single(ctx, &sighash, &pub_tmp, msg32);
+        secp256k1_compute_sighash_single(ctx, &sighash, &pub_tmp, pubkey_for_e, msg32);
     }
     /* calculate signature */
     secp256k1_scalar_set_b32(&sec, seckey32, &overflow);
@@ -497,6 +507,7 @@ int secp256k1_aggsig_verify_single(
     const unsigned char *msg32,
     const secp256k1_pubkey *pubnonce,
     const secp256k1_pubkey *pubkey,
+    const secp256k1_pubkey *pubkey_total,
     const int is_partial){
 
     secp256k1_scalar g_sc;
@@ -531,11 +542,11 @@ int secp256k1_aggsig_verify_single(
 
     /* compute e = sighash */
     if (pubnonce != NULL) {
-        secp256k1_compute_sighash_single(ctx, &sighash, pubnonce, msg32);
+        secp256k1_compute_sighash_single(ctx, &sighash, pubnonce, pubkey_total, msg32);
     } else {
         secp256k1_ge_set_xquad(&tmp_pubnonce_ge, &r_x);
         secp256k1_pubkey_save(&tmp_pk, &tmp_pubnonce_ge);
-        secp256k1_compute_sighash_single(ctx, &sighash, &tmp_pk, msg32);
+        secp256k1_compute_sighash_single(ctx, &sighash, &tmp_pk, pubkey_total, msg32);
     }
 
     /* Populate callback data */

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -50,7 +50,7 @@ static int secp256k1_compute_sighash_single(const secp256k1_context *ctx, secp25
     if (pubkey != NULL) {
       buflen = sizeof(buf);
       CHECK(secp256k1_ec_pubkey_serialize(ctx, buf, &buflen, pubkey, SECP256K1_EC_COMPRESSED));
-      secp256k1_sha256_write(&hasher, buf+1, 32);
+      secp256k1_sha256_write(&hasher, buf, 33);
     }
 
     /* Encode message */

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -48,6 +48,7 @@ static int secp256k1_compute_sighash_single(const secp256k1_context *ctx, secp25
 
     /* Encode public key */
     if (pubkey != NULL) {
+      buflen = sizeof(buf);
       CHECK(secp256k1_ec_pubkey_serialize(ctx, buf, &buflen, pubkey, SECP256K1_EC_COMPRESSED));
       secp256k1_sha256_write(&hasher, buf+1, 32);
     }

--- a/src/modules/aggsig/tests_impl.h
+++ b/src/modules/aggsig/tests_impl.h
@@ -29,6 +29,7 @@ void test_aggsig_api(void) {
     unsigned char sec_nonces[5][32];
     secp256k1_pubkey pub_nonces[5];
     unsigned char orig_sig;
+    unsigned char orig_msg;
     unsigned char *msg = seed;  /* shh ;) */
     const secp256k1_pubkey* pubkey_combiner[2];
     secp256k1_pubkey combiner_sum;
@@ -157,8 +158,10 @@ void test_aggsig_api(void) {
     CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
     sig[0]=orig_sig;
     CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    orig_msg=msg[0];
     msg[0]=99;
     CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    msg[0]=orig_msg;
 
     /* Test single api with pubkey in e */
     memset(sig, 0, sizeof(sig));

--- a/src/modules/aggsig/tests_impl.h
+++ b/src/modules/aggsig/tests_impl.h
@@ -213,8 +213,8 @@ void test_aggsig_api(void) {
         /* Randomize keys */
         for (j = 0; j < 2; j++) {
             random_scalar_order_test(&tmp_s);
-            secp256k1_scalar_get_b32(seckeys[i], &tmp_s);
-            CHECK(secp256k1_ec_pubkey_create(ctx, &pubkeys[i], seckeys[i]) == 1);
+            secp256k1_scalar_get_b32(seckeys[j], &tmp_s);
+            CHECK(secp256k1_ec_pubkey_create(ctx, &pubkeys[j], seckeys[j]) == 1);
         }
 
         /* Combine pubnonces */
@@ -245,7 +245,7 @@ void test_aggsig_api(void) {
         CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, &combiner_sum_2, 0));
         CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, 0));
 
-        /* And anything else doesnt' */
+        /* And anything else doesn't */
         CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, NULL, 0));
         CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], NULL, 0));
         CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], &combiner_sum_2, 0));

--- a/src/modules/aggsig/tests_impl.h
+++ b/src/modules/aggsig/tests_impl.h
@@ -147,27 +147,44 @@ void test_aggsig_api(void) {
 
     /* Test single api */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, seed));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, NULL, seed));
     CHECK(ecount == 20);
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], 0));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[1], 0));
     orig_sig=sig[0];
     sig[0]=99;
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
     sig[0]=orig_sig;
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], 0));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
     msg[0]=99;
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0],0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+
+    /* Test single api with pubkey in e */
+    memset(sig, 0, sizeof(sig));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, &pubkeys[2], seed));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[3], 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], &pubkeys[2], 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], NULL, 0));
+    orig_sig=sig[0];
+    sig[0]=99;
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
+    sig[0]=orig_sig;
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
+    msg[0]=99;
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
 
     /* Overriding sec nonce */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], NULL, NULL, seed));
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0],0));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], NULL, NULL, NULL, seed));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
 
     /* Overriding sec nonce and pub nonce encoded in e */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], &pubkeys[3], NULL, seed));
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &pubkeys[3], &pubkeys[0], 0));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], &pubkeys[3], NULL, NULL, seed));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &pubkeys[3], &pubkeys[0], NULL, 0));
 
     /* Testing aggsig exchange algorithm for Grin */
     /* ****************************************** */
@@ -190,41 +207,52 @@ void test_aggsig_api(void) {
             CHECK(secp256k1_ec_pubkey_create(ctx, &pub_nonces[j], sec_nonces[j]) == 1);
         }
 
+        /* Randomize keys */
+        for (j = 0; j < 2; j++) {
+            random_scalar_order_test(&tmp_s);
+            secp256k1_scalar_get_b32(seckeys[i], &tmp_s);
+            CHECK(secp256k1_ec_pubkey_create(ctx, &pubkeys[i], seckeys[i]) == 1);
+        }
+
         /* Combine pubnonces */
         pubkey_combiner[0]=&pub_nonces[0];
         pubkey_combiner[1]=&pub_nonces[1];
         CHECK(secp256k1_ec_pubkey_combine(ctx, &combiner_sum, pubkey_combiner, 2) == 1);
-
-        /* Create 2 partial signatures (Sender, Receiver)*/
-        CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], sec_nonces[0], &combiner_sum, &combiner_sum, seed));
-
-        /* Receiver verifies sender's Sig and signs */
-        CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &combiner_sum, &pubkeys[0], 1));
-        CHECK(secp256k1_aggsig_sign_single(sign, sig2, msg, seckeys[1], sec_nonces[1], &combiner_sum, &combiner_sum, seed));
-        /* sender verifies receiver's Sig then creates final combined sig */
-        CHECK(secp256k1_aggsig_verify_single(vrfy, sig2, msg, &combiner_sum, &pubkeys[1], 1));
-
-        sigs[0] = sig;
-        sigs[1] = sig2;
-        /* Add 2 sigs and nonces */
-        CHECK(secp256k1_aggsig_add_signatures_single(sign, combined_sig, (const unsigned char **) sigs, 2, &combiner_sum));
 
         /* Combine pubkeys */
         pubkey_combiner[0]=&pubkeys[0];
         pubkey_combiner[1]=&pubkeys[1];
         CHECK(secp256k1_ec_pubkey_combine(ctx, &combiner_sum_2, pubkey_combiner, 2) == 1);
 
+        /* Create 2 partial signatures (Sender, Receiver)*/
+        CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], sec_nonces[0], &combiner_sum, &combiner_sum, &combiner_sum_2, seed));
+
+        /* Receiver verifies sender's Sig and signs */
+        CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &combiner_sum, &pubkeys[0], &combiner_sum_2, 1));
+        CHECK(secp256k1_aggsig_sign_single(sign, sig2, msg, seckeys[1], sec_nonces[1], &combiner_sum, &combiner_sum, &combiner_sum_2, seed));
+        /* sender verifies receiver's Sig then creates final combined sig */
+        CHECK(secp256k1_aggsig_verify_single(vrfy, sig2, msg, &combiner_sum, &pubkeys[1], &combiner_sum_2, 1));
+
+        sigs[0] = sig;
+        sigs[1] = sig2;
+        /* Add 2 sigs and nonces */
+        CHECK(secp256k1_aggsig_add_signatures_single(sign, combined_sig, (const unsigned char **) sigs, 2, &combiner_sum));
+
         /* Ensure added sigs verify properly (with and without providing nonce_sum */
-        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, 0));
-        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, 0));
+        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, &combiner_sum_2, 0));
+        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, 0));
 
         /* And anything else doesnt' */
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, 0));
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], &combiner_sum_2, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, &combiner_sum_2, 0));
         msg[0]=1;
         msg[1]=2;
         msg[2]=3;
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, 0));
 
     }
     /*** End aggsig for Grin exchange test ***/


### PR DESCRIPTION
Optionally add a public key to the aggsig challenge in both the creation and verification of the signature. Compatibility with [BIP-schnorr](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki) (under "key prefixing")

 Also fixes https://github.com/mimblewimble/secp256k1-zkp/pull/21 and fixes https://github.com/mimblewimble/secp256k1-zkp/pull/23