### PR TITLE
Optional extra key in signature

### DIFF
--- a/include/secp256k1_aggsig.h
+++ b/include/secp256k1_aggsig.h
@@ -103,6 +103,7 @@ SECP256K1_API int secp256k1_aggsig_export_secnonce_single(
  *  In:      msg32: the message to sign (cannot be NULL)
  *           seckey32: the secret signing key (cannot be NULL)
  *           secnonce32: secret nonce to use. If NULL, a nonce will be generated
+ *           extra32: if non-NULL, add this key to s
  *           pubnonce_for_e: If this is non-NULL, encode this value in e instead of the derived
  *           pubnonce_total: If non-NULL, allow this signature to be included in combined sig
  *               in all cases by negating secnonce32 if the public nonce total has jacobi symbol 
@@ -116,11 +117,12 @@ SECP256K1_API int secp256k1_aggsig_sign_single(
     const unsigned char *msg32,
     const unsigned char *seckey32,
     const unsigned char* secnonce32,
+    const unsigned char* extra32,
     const secp256k1_pubkey *pubnonce_for_e,
     const secp256k1_pubkey* pubnonce_total,
     const secp256k1_pubkey* pubkey_for_e,
     const unsigned char* seed)
-SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(9) SECP256K1_WARN_UNUSED_RESULT;
+SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(10) SECP256K1_WARN_UNUSED_RESULT;
 
 /** Generate a single signature part in an aggregated signature
  *
@@ -187,6 +189,7 @@ SECP256K1_API int secp256k1_aggsig_add_signatures_single(
  *           pubnonce: if non-NULL, override the public nonce used to calculate e
  *           pubkey: the public key (cannot be NULL)
  *           pubkey_total: if non-NULL, encode this value in e
+ *           extra_pubkey: if non-NULL, subtract this pubkey from sG
  *           is_partial: whether to ignore the jacobi symbol of the combined R, set this to 1
  *               to verify partial signatures that may have had their secret nonces negated
  */
@@ -197,6 +200,7 @@ SECP256K1_API int secp256k1_aggsig_verify_single(
     const secp256k1_pubkey *pubnonce,
     const secp256k1_pubkey *pubkey,
     const secp256k1_pubkey *pubkey_total,
+    const secp256k1_pubkey *extra_pubkey,
     const int is_partial)
 SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5) SECP256K1_WARN_UNUSED_RESULT;
 

--- a/src/modules/aggsig/tests_impl.h
+++ b/src/modules/aggsig/tests_impl.h
@@ -148,46 +148,54 @@ void test_aggsig_api(void) {
 
     /* Test single api */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, NULL, seed));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, NULL, NULL, seed));
     CHECK(ecount == 20);
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], NULL, 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[1], 0));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], NULL, NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[1], NULL, 0));
     orig_sig=sig[0];
     sig[0]=99;
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, NULL, 0));
     sig[0]=orig_sig;
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, NULL, 0));
     orig_msg=msg[0];
     msg[0]=99;
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, NULL, 0));
     msg[0]=orig_msg;
 
     /* Test single api with pubkey in e */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, &pubkeys[2], seed));
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[3], 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], &pubkeys[2], 0));
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], NULL, 0));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], NULL, NULL, NULL, NULL, &pubkeys[2], seed));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[3], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], &pubkeys[2], NULL, 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[1], NULL, NULL, 0));
     orig_sig=sig[0];
     sig[0]=99;
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], NULL, 0));
     sig[0]=orig_sig;
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], NULL, 0));
     msg[0]=99;
-    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], 0));
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], &pubkeys[2], NULL, 0));
 
     /* Overriding sec nonce */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], NULL, NULL, NULL, seed));
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, 0));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], NULL, NULL, NULL, NULL, seed));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, NULL, &pubkeys[0], NULL, NULL, 0));
 
     /* Overriding sec nonce and pub nonce encoded in e */
     memset(sig, 0, sizeof(sig));
-    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], &pubkeys[3], NULL, NULL, seed));
-    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &pubkeys[3], &pubkeys[0], NULL, 0));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], NULL, &pubkeys[3], NULL, NULL, seed));
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &pubkeys[3], &pubkeys[0], NULL, NULL, 0));
+
+    /* Add extra key to the signature */
+    memset(sig, 0, sizeof(sig));
+    CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], seckeys[1], seckeys[2], &pubkeys[3], &pubkeys[3], &pubkeys[4], seed));
+    /* Check that it doesn't verify without the extra key */
+    CHECK(!secp256k1_aggsig_verify_single(vrfy, sig, msg, &pubkeys[3], &pubkeys[0], &pubkeys[4], NULL, 1));
+    /* And that it does with */
+    CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &pubkeys[3], &pubkeys[0], &pubkeys[4], &pubkeys[2], 1));
 
     /* Testing aggsig exchange algorithm for Grin */
     /* ****************************************** */
@@ -228,13 +236,13 @@ void test_aggsig_api(void) {
         CHECK(secp256k1_ec_pubkey_combine(ctx, &combiner_sum_2, pubkey_combiner, 2) == 1);
 
         /* Create 2 partial signatures (Sender, Receiver)*/
-        CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], sec_nonces[0], &combiner_sum, &combiner_sum, &combiner_sum_2, seed));
+        CHECK(secp256k1_aggsig_sign_single(sign, sig, msg, seckeys[0], sec_nonces[0], NULL, &combiner_sum, &combiner_sum, &combiner_sum_2, seed));
 
         /* Receiver verifies sender's Sig and signs */
-        CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &combiner_sum, &pubkeys[0], &combiner_sum_2, 1));
-        CHECK(secp256k1_aggsig_sign_single(sign, sig2, msg, seckeys[1], sec_nonces[1], &combiner_sum, &combiner_sum, &combiner_sum_2, seed));
+        CHECK(secp256k1_aggsig_verify_single(vrfy, sig, msg, &combiner_sum, &pubkeys[0], &combiner_sum_2, NULL, 1));
+        CHECK(secp256k1_aggsig_sign_single(sign, sig2, msg, seckeys[1], sec_nonces[1], NULL, &combiner_sum, &combiner_sum, &combiner_sum_2, seed));
         /* sender verifies receiver's Sig then creates final combined sig */
-        CHECK(secp256k1_aggsig_verify_single(vrfy, sig2, msg, &combiner_sum, &pubkeys[1], &combiner_sum_2, 1));
+        CHECK(secp256k1_aggsig_verify_single(vrfy, sig2, msg, &combiner_sum, &pubkeys[1], &combiner_sum_2, NULL, 1));
 
         sigs[0] = sig;
         sigs[1] = sig2;
@@ -242,21 +250,20 @@ void test_aggsig_api(void) {
         CHECK(secp256k1_aggsig_add_signatures_single(sign, combined_sig, (const unsigned char **) sigs, 2, &combiner_sum));
 
         /* Ensure added sigs verify properly (with and without providing nonce_sum */
-        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, &combiner_sum_2, 0));
-        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, 0));
+        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, &combiner_sum_2, NULL, 0));
+        CHECK(secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, NULL, 0));
 
         /* And anything else doesn't */
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, NULL, 0));
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], NULL, 0));
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], &combiner_sum_2, 0));
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, NULL, 0));
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, &combiner_sum_2, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &combiner_sum, &combiner_sum_2, NULL, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], NULL, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &pub_nonces[1], &combiner_sum_2, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, NULL, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, &pub_nonces[0], &combiner_sum_2, &combiner_sum_2, NULL, 0));
         msg[0]=1;
         msg[1]=2;
         msg[2]=3;
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, NULL, 0));
-        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, 0));
-
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, NULL, NULL, 0));
+        CHECK(!secp256k1_aggsig_verify_single(vrfy, combined_sig, msg, NULL, &combiner_sum_2, &combiner_sum_2, NULL, 0));
     }
     /*** End aggsig for Grin exchange test ***/
 


### PR DESCRIPTION
Allow for creation and verification of modified signature `(s+x,kG)` with extra key `x`.