### PR TITLE
Updates based on audit

### DIFF
--- a/src/modules/bulletproofs/main_impl.h
+++ b/src/modules/bulletproofs/main_impl.h
@@ -237,6 +237,7 @@ int secp256k1_bulletproof_rangeproof_prove(
         int overflow;
         secp256k1_scalar_set_b32(&blinds[i], blind[i], &overflow);
         if (overflow || secp256k1_scalar_is_zero(&blinds[i])) {
+            secp256k1_scratch_deallocate_frame(scratch);
             return 0;
         }
         
@@ -261,11 +262,17 @@ int secp256k1_bulletproof_rangeproof_prove(
 
     if (t_one != NULL) {
         tge = malloc(2*sizeof(secp256k1_ge));
+        if (tge == NULL){
+            secp256k1_scratch_deallocate_frame(scratch);
+            return 0;
+        }
         if (tau_x != NULL) {
             if (!secp256k1_pubkey_load(ctx, &tge[0], t_one)) {
+                secp256k1_scratch_deallocate_frame(scratch);
                 return 0;
             }
             if (!secp256k1_pubkey_load(ctx, &tge[1], t_two)) {
+                secp256k1_scratch_deallocate_frame(scratch);
                 return 0;
             }
         }


### PR DESCRIPTION
I've made some comments throughout (mostly minor changes). Some other observations:

* No changes for 2.1 as there's no way to ensure the compiler doesn't optimise this out
* No changes for 3.3
* 3.4 I believe is using some short circuiting behavior to return values to the caller, even though the proof may not have been created, @jaspervdm can confirm 
* 3.6 I believe there is an ARG_CHECK for nbits already (I might be missing something about what the issue is saying?)
