### PR TITLE
Fix the expected allocation count which would fail allocation on 32-bit systems

### DIFF
--- a/src/modules/bulletproofs/main_impl.h
+++ b/src/modules/bulletproofs/main_impl.h
@@ -141,7 +141,7 @@ int secp256k1_bulletproof_rangeproof_verify_multi(const secp256k1_context* ctx, 
     }
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
 
-    if (!secp256k1_scratch_allocate_frame(scratch, n_proofs * (sizeof(*value_genp) + sizeof(*commitp) + n_commits * sizeof(**commitp)), 1 + n_proofs)) {
+    if (!secp256k1_scratch_allocate_frame(scratch, n_proofs * (sizeof(*value_genp) + sizeof(*commitp) + n_commits * sizeof(**commitp)), 2 + n_proofs)) {
         return 0;
     }
 


### PR DESCRIPTION
When running Grin server on Raspberry Pi 3, this issue manifests itself as a segfault due to allocation failure (mentioned here https://github.com/mimblewimble/grin/issues/1681#issuecomment-447974380).

The reason is we made 3 allocations (when `n_proofs == 1`) right afterwards but only reserved 2 alignment slots. On 64-bit system, all 3 allocations happen to fit in 2 alignment slots so we are fine, but on 32-bit system we are 4 bytes short and the last allocation request would fail.