### PR TITLE
Functions to inverse and negate private key, commit with 2 blinding factors

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -652,7 +652,17 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
  * Args:   ctx:    pointer to a context object (cannot be NULL).
  * In/Out: seckey: pointer to a 32-byte private key.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_inverse(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_inv(
+    const secp256k1_context* ctx,
+    unsigned char *seckey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+
+/** Tweak a private key by negating it.
+ * Returns: 0 if the input was out of range. 1 otherwise.
+ * Args:   ctx:    pointer to a context object (cannot be NULL).
+ * In/Out: seckey: pointer to a 32-byte private key.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_neg(
     const secp256k1_context* ctx,
     unsigned char *seckey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -647,6 +647,16 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
     size_t n
 ) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
+/** Tweak a private key by inverting it.
+ * Returns: 0 if the input was out of range. 1 otherwise.
+ * Args:   ctx:    pointer to a context object (cannot be NULL).
+ * In/Out: seckey: pointer to a 32-byte private key.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_inverse(
+    const secp256k1_context* ctx,
+    unsigned char *seckey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/secp256k1_commitment.h
+++ b/include/secp256k1_commitment.h
@@ -81,6 +81,29 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_pedersen_commit(
   const secp256k1_generator *blind_gen
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
 
+/** Generate a Pedersen commitment from two blinding factors.
+ *  Returns 1: Commitment successfully created.
+ *          0: Error. The blinding factor is larger than the group order
+ *             (probability for random 32 byte number < 2^-127) or results in the
+ *             point at infinity. Retry with a different factor.
+ *  In:     ctx:        pointer to a context object (cannot be NULL)
+ *          blind:      pointer to a 32-byte blinding factor (cannot be NULL)
+ *          value:      pointer to a 32-byte blinding factor (cannot be NULL)
+ *          value_gen:  value generator 'h'
+ *          blind_gen:  blinding factor generator 'g'
+ *  Out:    commit:     pointer to the commitment (cannot be NULL)
+ *
+ *  Blinding factors can be generated and verified in the same way as secp256k1 private keys for ECDSA.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_pedersen_blind_commit(
+  const secp256k1_context* ctx,
+  secp256k1_pedersen_commitment *commit,
+  const unsigned char *blind,
+  const unsigned char *value,
+  const secp256k1_generator *value_gen,
+  const secp256k1_generator *blind_gen
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
+
 /** Computes the sum of multiple positive and negative blinding factors.
  *  Returns 1: Sum successfully computed.
  *          0: Error. A blinding factor is larger than the group order

--- a/src/modules/commitment/pedersen_impl.h
+++ b/src/modules/commitment/pedersen_impl.h
@@ -35,4 +35,22 @@ SECP256K1_INLINE static void secp256k1_pedersen_ecmult(secp256k1_gej *rj, const 
     secp256k1_scalar_clear(&vs);
 }
 
+SECP256K1_INLINE static void secp256k1_pedersen_blind_ecmult(secp256k1_gej *rj, const secp256k1_scalar *sec, const secp256k1_scalar *value, const secp256k1_ge* value_gen, const secp256k1_ge* blind_gen) {
+    secp256k1_gej bj;
+    secp256k1_ge bp;
+
+    secp256k1_ecmult_const(rj, value_gen, value, 256);
+    secp256k1_ecmult_const(&bj, blind_gen, sec, 256);
+
+    /* zero blinding factor indicates that we are not trying to be zero-knowledge,
+     * so not being constant-time in this case is OK. */
+    if (!secp256k1_gej_is_infinity(&bj)) {
+        secp256k1_ge_set_gej(&bp, &bj);
+        secp256k1_gej_add_ge(rj, rj, &bp);
+    }
+
+    secp256k1_gej_clear(&bj);
+    secp256k1_ge_clear(&bp);
+}
+
 #endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -608,6 +608,26 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
     return 1;
 }
 
+int secp256k1_ec_privkey_tweak_inverse(const secp256k1_context* ctx, unsigned char *seckey) {
+    secp256k1_scalar sec;
+    secp256k1_scalar inv;
+    int ret = 0;
+    int overflow = 0;
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(seckey != NULL);
+
+    secp256k1_scalar_set_b32(&sec, seckey, &overflow);
+    ret = !overflow;
+    memset(seckey, 0, 32);
+    if (ret) {
+        secp256k1_scalar_inverse(&inv, &sec);
+        secp256k1_scalar_get_b32(seckey, &inv);
+        secp256k1_scalar_clear(&inv);
+    }
+    secp256k1_scalar_clear(&sec);
+    return ret;
+}
+
 #ifdef ENABLE_MODULE_ECDH
 # include "modules/ecdh/main_impl.h"
 #endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -608,7 +608,7 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
     return 1;
 }
 
-int secp256k1_ec_privkey_tweak_inverse(const secp256k1_context* ctx, unsigned char *seckey) {
+int secp256k1_ec_privkey_tweak_inv(const secp256k1_context* ctx, unsigned char *seckey) {
     secp256k1_scalar sec;
     secp256k1_scalar inv;
     int ret = 0;
@@ -623,6 +623,26 @@ int secp256k1_ec_privkey_tweak_inverse(const secp256k1_context* ctx, unsigned ch
         secp256k1_scalar_inverse(&inv, &sec);
         secp256k1_scalar_get_b32(seckey, &inv);
         secp256k1_scalar_clear(&inv);
+    }
+    secp256k1_scalar_clear(&sec);
+    return ret;
+}
+
+int secp256k1_ec_privkey_tweak_neg(const secp256k1_context* ctx, unsigned char *seckey) {
+    secp256k1_scalar sec;
+    secp256k1_scalar neg;
+    int ret = 0;
+    int overflow = 0;
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(seckey != NULL);
+
+    secp256k1_scalar_set_b32(&sec, seckey, &overflow);
+    ret = !overflow;
+    memset(seckey, 0, 32);
+    if (ret) {
+        secp256k1_scalar_negate(&neg, &sec);
+        secp256k1_scalar_get_b32(seckey, &neg);
+        secp256k1_scalar_clear(&neg);
     }
     secp256k1_scalar_clear(&sec);
     return ret;

--- a/src/tests.c
+++ b/src/tests.c
@@ -3988,6 +3988,23 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
     secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
+    /* Inverse of secret key 1 is 1 */
+    memset(ctmp, 0, 32);
+    ctmp[31] = 0x01;
+    memset(ctmp2, 0, 32);
+    ctmp2[31] = 0x01;
+    CHECK(secp256k1_ec_privkey_tweak_inverse(ctx, ctmp2) == 1);
+    CHECK(memcmp(ctmp, ctmp2, 32) == 0);
+    /* Secret key times inverse is 1 */
+    memset(ctmp, 0, 32);
+    ctmp[31] = 0xac;
+    memset(ctmp2, 0, 32);
+    ctmp2[31] = 0xac;
+    CHECK(secp256k1_ec_privkey_tweak_inverse(ctx, ctmp2) == 1);
+    CHECK(secp256k1_ec_privkey_tweak_mul(ctx, ctmp, ctmp2) == 1);
+    memset(ctmp2, 0, 32);
+    ctmp2[31] = 0x01;
+    CHECK(memcmp(ctmp, ctmp2, 32) == 0);
 }
 
 void random_sign(secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *key, const secp256k1_scalar *msg, int *recid) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -4046,6 +4046,15 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_privkey_tweak_mul(ctx, ctmp2, ctmp) == 1);
     CHECK(secp256k1_ec_privkey_tweak_neg(ctx, ctmp) == 1);
     CHECK(memcmp(ctmp, ctmp2, 32) == 0);
+    /* -1/x == 1/(-x) */
+    random_scalar_order_test(&tmp_s);
+    secp256k1_scalar_get_b32(ctmp, &tmp_s);
+    memcpy(ctmp2, ctmp, 32);
+    CHECK(secp256k1_ec_privkey_tweak_neg(ctx, ctmp) == 1);
+    CHECK(secp256k1_ec_privkey_tweak_inv(ctx, ctmp) == 1);
+    CHECK(secp256k1_ec_privkey_tweak_inv(ctx, ctmp2) == 1);
+    CHECK(secp256k1_ec_privkey_tweak_neg(ctx, ctmp2) == 1);
+    CHECK(memcmp(ctmp, ctmp2, 32) == 0);
 }
 
 void random_sign(secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *key, const secp256k1_scalar *msg, int *recid) {


### PR DESCRIPTION
This PR adds 3 new convenience functions (and corresponding tests): 
- `secp256k1_ec_privkey_tweak_inv` - inverts the private key (`x` 🡒 `x^(-1)`)
- `secp256k1_ec_privkey_tweak_neg` - negates the private key (`x` 🡒 `-x`)
- `secp256k1_pedersen_blind_commit` - pedersen commitment with 2 blinding factors instead of blinding factor and u64