### PR TITLE
fix the bench_bulletproof for prove and rewind api change

### DIFF
--- a/src/bench_bulletproof.c
+++ b/src/bench_bulletproof.c
@@ -80,7 +80,7 @@ static void bench_bulletproof_rangeproof_setup(void* arg) {
         memcpy(data->commit[i], data->commit[0], data->n_commits * sizeof(*data->commit[0]));
     }
 
-    CHECK(secp256k1_bulletproof_rangeproof_prove(data->common->ctx, data->common->scratch, data->common->generators, data->common->proof[0], &data->common->plen, data->value, NULL, data->blind, data->n_commits, data->common->value_gen, data->nbits, data->common->nonce, NULL, 0) == 1);
+    CHECK(secp256k1_bulletproof_rangeproof_prove(data->common->ctx, data->common->scratch, data->common->generators, data->common->proof[0], &data->common->plen, NULL, NULL, NULL, data->value, NULL, data->blind, NULL, data->n_commits, data->common->value_gen, data->nbits, data->common->nonce, NULL, NULL, 0, NULL) == 1);
     for (i = 1; i < data->common->n_proofs; i++) {
         memcpy(data->common->proof[i], data->common->proof[0], data->common->plen);
         CHECK(secp256k1_bulletproof_rangeproof_verify(data->common->ctx, data->common->scratch, data->common->generators, data->common->proof[i], data->common->plen, NULL, data->commit[i], data->n_commits, data->nbits, &data->common->value_gen[0], NULL, 0) == 1);
@@ -88,7 +88,7 @@ static void bench_bulletproof_rangeproof_setup(void* arg) {
     CHECK(secp256k1_bulletproof_rangeproof_verify(data->common->ctx, data->common->scratch, data->common->generators, data->common->proof[0], data->common->plen, NULL, data->commit[0], data->n_commits, data->nbits, data->common->value_gen, NULL, 0) == 1);
     CHECK(secp256k1_bulletproof_rangeproof_verify_multi(data->common->ctx, data->common->scratch, data->common->generators, (const unsigned char **) data->common->proof, data->common->n_proofs, data->common->plen, NULL, (const secp256k1_pedersen_commitment **) data->commit, data->n_commits, data->nbits, data->common->value_gen, NULL, 0) == 1);
     if (data->n_commits == 1) {
-        CHECK(secp256k1_bulletproof_rangeproof_rewind(data->common->ctx, data->common->generators, &v, blind, data->common->proof[0], data->common->plen, 0, data->commit[0], &data->common->value_gen[0], data->common->nonce, NULL, 0) == 1);
+        CHECK(secp256k1_bulletproof_rangeproof_rewind(data->common->ctx, data->common->generators, &v, blind, data->common->proof[0], data->common->plen, 0, data->commit[0], &data->common->value_gen[0], data->common->nonce, NULL, 0, NULL) == 1);
     }
 }
 
@@ -127,7 +127,7 @@ static void bench_bulletproof_rangeproof_prove(void* arg) {
     bench_bulletproof_rangeproof_t *data = (bench_bulletproof_rangeproof_t*)arg;
     size_t i;
     for (i = 0; i < 25; i++) {
-        CHECK(secp256k1_bulletproof_rangeproof_prove(data->common->ctx, data->common->scratch, data->common->generators, data->common->proof[0], &data->common->plen, data->value, NULL, data->blind, data->n_commits, data->common->value_gen, data->nbits, data->common->nonce, NULL, 0) == 1);
+        CHECK(secp256k1_bulletproof_rangeproof_prove(data->common->ctx, data->common->scratch, data->common->generators, data->common->proof[0], &data->common->plen, NULL, NULL, NULL, data->value, NULL, data->blind, NULL, data->n_commits, data->common->value_gen, data->nbits, data->common->nonce, NULL, NULL, 0, NULL) == 1);
     }
 }
 
@@ -147,7 +147,7 @@ static void bench_bulletproof_rangeproof_rewind_succeed(void* arg) {
     bench_bulletproof_rangeproof_t *data = (bench_bulletproof_rangeproof_t*)arg;
 
     for (i = 0; i < data->common->iters; i++) {
-        CHECK(secp256k1_bulletproof_rangeproof_rewind(data->common->ctx, data->common->generators, &v, blind, data->common->proof[0], data->common->plen, 0, data->commit[0], &data->common->value_gen[0], data->common->nonce, NULL, 0) == 1);
+        CHECK(secp256k1_bulletproof_rangeproof_rewind(data->common->ctx, data->common->generators, &v, blind, data->common->proof[0], data->common->plen, 0, data->commit[0], &data->common->value_gen[0], data->common->nonce, NULL, 0, NULL) == 1);
     }
 }
 
@@ -159,7 +159,7 @@ static void bench_bulletproof_rangeproof_rewind_fail(void* arg) {
 
     data->common->nonce[0] ^= 1;
     for (i = 0; i < data->common->iters; i++) {
-        CHECK(secp256k1_bulletproof_rangeproof_rewind(data->common->ctx, data->common->generators, &v, blind, data->common->proof[0], data->common->plen, 0, data->commit[0], &data->common->value_gen[0], data->common->nonce, NULL, 0) == 0);
+        CHECK(secp256k1_bulletproof_rangeproof_rewind(data->common->ctx, data->common->generators, &v, blind, data->common->proof[0], data->common->plen, 0, data->commit[0], &data->common->value_gen[0], data->common->nonce, NULL, 0, NULL) == 0);
     }
     data->common->nonce[0] ^= 1;
 }


### PR DESCRIPTION
Fix the building error in bench_bulletproof.
We have changes in _prove and _rewind api, but the test codes had been left behind.