### PR TITLE
fix the test commitment

### DIFF
--- a/src/modules/commitment/tests_impl.h
+++ b/src/modules/commitment/tests_impl.h
@@ -41,14 +41,13 @@ static void test_commitment_api(void) {
     secp256k1_context_set_illegal_callback(both, counting_illegal_callback_fn, &ecount);
 
     secp256k1_rand256(blind);
-    /* TODO: fix these tests */
-    /* CHECK(secp256k1_pedersen_commit(none, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 0);
+    CHECK(secp256k1_pedersen_commit(none, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
     CHECK(ecount == 1);
-    CHECK(secp256k1_pedersen_commit(vrfy, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 0);
-    CHECK(ecount == 2);*/
+    CHECK(secp256k1_pedersen_commit(vrfy, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
+    CHECK(ecount == 1);
+    CHECK(secp256k1_pedersen_commit(sign, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
+    CHECK(ecount == 1);
     ecount = 2;
-    CHECK(secp256k1_pedersen_commit(sign, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) != 0);
-    CHECK(ecount == 2);
 
     CHECK(secp256k1_pedersen_commit(sign, NULL, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 0);
     CHECK(ecount == 3);

--- a/src/modules/commitment/tests_impl.h
+++ b/src/modules/commitment/tests_impl.h
@@ -29,7 +29,7 @@ static void test_commitment_api(void) {
     secp256k1_context *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
     secp256k1_context *vrfy = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     secp256k1_context *both = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-    int32_t ecount;
+    int32_t ecount = 0;
 
     secp256k1_context_set_error_callback(none, counting_illegal_callback_fn, &ecount);
     secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, &ecount);
@@ -42,11 +42,11 @@ static void test_commitment_api(void) {
 
     secp256k1_rand256(blind);
     CHECK(secp256k1_pedersen_commit(none, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
-    CHECK(ecount == 1);
+    CHECK(ecount == 0);
     CHECK(secp256k1_pedersen_commit(vrfy, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
-    CHECK(ecount == 1);
+    CHECK(ecount == 0);
     CHECK(secp256k1_pedersen_commit(sign, &commit, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
-    CHECK(ecount == 1);
+    CHECK(ecount == 0);
     ecount = 2;
 
     CHECK(secp256k1_pedersen_commit(sign, NULL, blind, val, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 0);


### PR DESCRIPTION
The `secp256k1_pedersen_commit` api doesn't really use the `ctx` parameter (anything with not null is ok for it), so whatever we use (`none`, `vrfy`, or `sign`) the result will be same.

According to the discussion on upstream: https://github.com/ElementsProject/secp256k1-zkp/pull/23/files#r242390153, the 'ctx' parameter here is just 
> For reasons of API consistency we prefer to have the context object in every public-facing function.

So, let's fix it by ourselves to prepare for enabling the Travis-CI for this repo.


