### PR TITLE
typo?

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -98,7 +98,7 @@ static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a);
 /** If a has a square root, it is computed in r and 1 is returned. If a does not
  *  have a square root, the root of its negation is computed and 0 is returned.
  *  The input's magnitude can be at most 8. The output magnitude is 1 (but not
- *  guaranteed to be normalized). The result in r will always be a square
+ *  guaranteed to be normalized). The result in r will always be a square root
  *  itself. */
 static int secp256k1_fe_sqrt(secp256k1_fe *r, const secp256k1_fe *a);
 

--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -177,7 +177,10 @@ static void shallue_van_de_woestijne(secp256k1_ge* ge, const secp256k1_fe* t) {
      * determine the Jacobi symbol of the produced y coordinate. Since the
      * rest of the algorithm only uses t^2, we can safely use another criterion
      * as long as negation of t results in negation of the y coordinate. Here
-     * we choose to use t's oddness, as it is faster to determine. */
+     * we choose to use t's oddness, as it is faster to determine. 
+     
+     * this is acceptable only because the solution from secp256k1_fe_sqrt is always a square.
+     */
     secp256k1_fe_negate(&tmp, &ge->y, 1);
     secp256k1_fe_cmov(&ge->y, &tmp, secp256k1_fe_is_odd(t));
 }


### PR DESCRIPTION
the returned r should always be a root of a square, either a or -a.