### PR TITLE
Add Public Key to Pedersen Commit Function

### DIFF
--- a/include/secp256k1_commitment.h
+++ b/include/secp256k1_commitment.h
@@ -244,6 +244,23 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_pedersen_commitment_to_
   const secp256k1_pedersen_commitment* commit
 );
 
+/** Converts pubkey to a pedersen commit
+ *
+ * Returns 1: Commit succesfully computed.
+ *         0: Error.
+*
+ * In:                 ctx: pointer to a context object
+ *                   pubkey: pointer to a single pubkey
+ * Out:              commit: resulting commit
+ *
+ */
+
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_pubkey_to_pedersen_commitment(
+  const secp256k1_context* ctx,
+  secp256k1_pedersen_commitment* commit,
+  const secp256k1_pubkey* pubkey
+);
+
 # ifdef __cplusplus
 }
 # endif

--- a/src/modules/commitment/main_impl.h
+++ b/src/modules/commitment/main_impl.h
@@ -163,31 +163,17 @@ int secp256k1_pedersen_commitment_to_pubkey(const secp256k1_context* ctx, secp25
 }
 
 int secp256k1_pubkey_to_pedersen_commitment(const secp256k1_context* ctx, secp256k1_pedersen_commitment* commit, const secp256k1_pubkey* pubkey)  {
-    secp256k1_fe fe;
-    secp256k1_ge P, Q;
-    int i;
+    secp256k1_ge P;
 
-    unsigned char commit_raw[32];
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(commit != NULL);
     memset(commit, 0, sizeof(*commit));
     ARG_CHECK(pubkey != NULL);
 
-   for (i = 0; i<32; i++){
-      commit_raw[i] = pubkey->data[31-i];
-    }
-
-    secp256k1_fe_set_b32(&fe, &commit_raw[0]);
-    secp256k1_ge_set_xquad(&Q, &fe);
-
     secp256k1_pubkey_load(ctx, &P, pubkey);
-    if (!secp256k1_fe_is_quad_var(&P.y)) {
-        secp256k1_ge_neg(&Q, &Q);
-    }
+    secp256k1_pedersen_commitment_save(commit, &P);
 
-    secp256k1_pedersen_commitment_save(commit, &Q);
     secp256k1_ge_clear(&P);
-    secp256k1_ge_clear(&Q);
     return 1;
 }
 

--- a/src/modules/commitment/main_impl.h
+++ b/src/modules/commitment/main_impl.h
@@ -161,6 +161,22 @@ int secp256k1_pedersen_commitment_to_pubkey(const secp256k1_context* ctx, secp25
     return 1;
 }
 
+int secp256k1_pubkey_to_pedersen_commitment(const secp256k1_context* ctx, secp256k1_pedersen_commitment* commit, const secp256k1_pubkey* pubkey)  {
+    secp256k1_ge Q;
+    secp256k1_fe fe;
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(commit != NULL);
+    memset(commit, 0, sizeof(*commit));
+    ARG_CHECK(pubkey != NULL);
+
+    secp256k1_fe_set_b32(&fe, &pubkey->data[0]);
+    secp256k1_ge_set_xquad(&Q, &fe);
+    secp256k1_pedersen_commitment_save(commit, &Q);
+
+    secp256k1_ge_clear(&Q);
+    return 1;
+}
+
 /** Takes a list of n pointers to 32 byte blinding values, the first negs of which are treated with positive sign and the rest
  *  negative, then calculates an additional blinding value that adds to zero.
  */

--- a/src/modules/commitment/tests_impl.h
+++ b/src/modules/commitment/tests_impl.h
@@ -136,7 +136,8 @@ static void test_commitment_api(void) {
 
     /* Test conversion of commit to pubkey and back */
     CHECK(secp256k1_pedersen_commitment_to_pubkey(sign, &pubkey, &commit) == 1);
-    CHECK(secp256k1_pubkey_to_pedersen_commitment(sign, &commit, &pubkey) == 1);
+    CHECK(secp256k1_pubkey_to_pedersen_commitment(sign, &commit2, &pubkey) == 1);
+    CHECK(memcmp(&commit.data, &commit2.data, 33) == 0);
 
     secp256k1_context_destroy(none);
     secp256k1_context_destroy(sign);

--- a/src/modules/commitment/tests_impl.h
+++ b/src/modules/commitment/tests_impl.h
@@ -19,12 +19,16 @@
 static void test_commitment_api(void) {
     secp256k1_pedersen_commitment commit;
     secp256k1_pedersen_commitment commit2;
+    secp256k1_pubkey pubkey;
     const secp256k1_pedersen_commitment *commit_ptr = &commit;
     unsigned char blind[32];
     unsigned char blind_out[32];
     const unsigned char *blind_ptr = blind;
     unsigned char *blind_out_ptr = blind_out;
     uint64_t val = secp256k1_rand32();
+    secp256k1_scalar tmp_s;
+    unsigned char out[33];
+    unsigned char out2[33];
 
     secp256k1_context *none = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     secp256k1_context *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
@@ -96,9 +100,6 @@ static void test_commitment_api(void) {
 
     /* Test commit with integer and blinding factor */
     /* Value: 1*/
-    secp256k1_scalar tmp_s;
-    unsigned char out[33];
-    unsigned char out2[33];
     random_scalar_order_test(&tmp_s);
     secp256k1_scalar_get_b32(blind, &tmp_s);
     memset(blind_out, 0, 32);
@@ -132,6 +133,10 @@ static void test_commitment_api(void) {
     CHECK(secp256k1_pedersen_blind_commit(sign, &commit2, blind, blind_out, &secp256k1_generator_const_h, &secp256k1_generator_const_g) == 1);
     CHECK(secp256k1_pedersen_commitment_serialize(sign, out2, &commit2) == 1);
     CHECK(memcmp(out, out2, 33) == 0);
+
+    /* Test conversion of commit to pubkey and back */
+    CHECK(secp256k1_pedersen_commitment_to_pubkey(sign, &pubkey, &commit) == 1);
+    CHECK(secp256k1_pubkey_to_pedersen_commitment(sign, &commit, &pubkey) == 1);
 
     secp256k1_context_destroy(none);
     secp256k1_context_destroy(sign);

--- a/src/tests.c
+++ b/src/tests.c
@@ -3769,6 +3769,7 @@ void run_eckey_edge_case_test(void) {
     secp256k1_pubkey pubkey2;
     secp256k1_pubkey pubkey_one;
     secp256k1_pubkey pubkey_negone;
+    secp256k1_scalar tmp_s;
     const secp256k1_pubkey *pubkeys[3];
     size_t len;
     int32_t ecount;
@@ -3998,7 +3999,6 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_privkey_tweak_inv(ctx, ctmp2) == 1);
     CHECK(memcmp(ctmp, ctmp2, 32) == 0);
     /* Inverse of inverse */
-    secp256k1_scalar tmp_s;
     random_scalar_order_test(&tmp_s);
     secp256k1_scalar_get_b32(ctmp, &tmp_s);
     memcpy(ctmp2, ctmp, 32);


### PR DESCRIPTION
* Adds hitherto missing function to convert Public Keys to Pedersen Commits.
* Also cleans up a few warnings.