### PR TITLE
Fix memory leaks detected by ASAN

### DIFF
--- a/src/modules/bulletproofs/main_impl.h
+++ b/src/modules/bulletproofs/main_impl.h
@@ -283,6 +283,7 @@ int secp256k1_bulletproof_rangeproof_prove(
         secp256k1_pubkey_save(t_one, &tge[0]);
         secp256k1_pubkey_save(t_two, &tge[1]);
     }
+    free(tge);
     secp256k1_scratch_deallocate_frame(scratch);
     return ret;
 }

--- a/src/modules/bulletproofs/tests_impl.h
+++ b/src/modules/bulletproofs/tests_impl.h
@@ -626,6 +626,13 @@ void test_multi_party_bulletproof(size_t n_parties, secp256k1_scratch_space* scr
     blind_ptr[0] = blinds[0];
     CHECK(secp256k1_bulletproof_rangeproof_prove(ctx, scratch, gens, proof, &plen, tau_x_sum, &t_1_sum, &t_2_sum, value, NULL, blind_ptr, commit_ptr, 1, &secp256k1_generator_const_h, 64, common_nonce, nonces[0], NULL, 0, NULL) == 1);
     CHECK(secp256k1_bulletproof_rangeproof_verify(ctx, scratch, gens, proof, plen, NULL, commit, 1, 64, &secp256k1_generator_const_h, NULL, 0) == 1);
+
+    /* Cleanup */
+    for (j = 0; j < n_parties; j++) {
+        free(t_1s[j]);
+        free(t_2s[j]);
+        free(partial_commits[j]);
+    }
 }
 
 void run_bulletproofs_tests(void) {

--- a/src/modules/commitment/tests_impl.h
+++ b/src/modules/commitment/tests_impl.h
@@ -333,6 +333,8 @@ void test_switch(void) {
     CHECK(memcmp(blind_switch, blind, 32) != 0);
     CHECK(secp256k1_blind_switch(local_ctx, blind_switch_2, blind, val, &GENERATOR_H, &GENERATOR_G, &GENERATOR_J_PUB));
     CHECK(memcmp(blind_switch_2, blind_switch, 32) == 0);
+
+    secp256k1_context_destroy(local_ctx);
 }
 
 void run_commitment_tests(void) {


### PR DESCRIPTION
Clean up some stray allocations in bulletproofs and commitments tests, and one allocation in the main bulletproofs impl