### PR TITLE
Signature Subtraction function

### DIFF
--- a/include/secp256k1_aggsig.h
+++ b/include/secp256k1_aggsig.h
@@ -145,8 +145,11 @@ SECP256K1_API int secp256k1_aggsig_partial_sign(
 
 /** Subtract a partial signature from a completed signature, resulting in another partial signature
  *
- *  Returns: 0 on failure, 1 if there is only one possible result, 2 if there is a second possiblity due
- *           to two possiblities for the chosen y value of the original public nonce
+ *  Returns: 0 on failure due to an argument or unexpected calculation error
+             -1 if the provided signatures result in no possible nonce with 
+                a y value that is a quadratic residue
+             1 if there is only one possible result
+             2 if there is a second possiblity for the chosen y value of the original public nonce
  *  Args:    ctx: an existing context object, initialized for verifying (cannot be NULL)
  *  Out:     result: the (partial) signature resulting from subtracting partial from sig64
  *           result_alt: alternative possible signature resulting from subtracting partial from sig64

--- a/include/secp256k1_aggsig.h
+++ b/include/secp256k1_aggsig.h
@@ -143,6 +143,25 @@ SECP256K1_API int secp256k1_aggsig_partial_sign(
     size_t index
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_WARN_UNUSED_RESULT;
 
+/** Subtract a partial signature from a completed signature, resulting in another partial signature
+ *
+ *  Returns: 0 on failure, 1 if there is only one possible result, 2 if there is a second possiblity due
+ *           to two possiblities for the chosen y value of the original public nonce
+ *  Args:    ctx: an existing context object, initialized for verifying (cannot be NULL)
+ *  Out:     result: the (partial) signature resulting from subtracting partial from sig64
+ *           result_alt: alternative possible signature resulting from subtracting partial from sig64
+ *  In:      sig64: a completed signature
+ *           partial64: the signature (partial) to subtract from sig64
+ */
+
+SECP256K1_API int secp256k1_aggsig_subtract_partial_signature(
+    const secp256k1_context* ctx,
+    unsigned char *result,
+    unsigned char *result_alt,
+    const unsigned char *sig64,
+    const unsigned char *partial64
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_WARN_UNUSED_RESULT;
+
 
 /** Aggregate multiple signature parts into a single aggregated signature
  *

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -371,6 +371,7 @@ int secp256k1_aggsig_subtract_partial_signature(
 
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(result != NULL);
+    ARG_CHECK(result_alt != NULL);
     ARG_CHECK(sig64 != NULL);
     ARG_CHECK(partial64 != NULL);
     (void) ctx;
@@ -398,7 +399,7 @@ int secp256k1_aggsig_subtract_partial_signature(
     /* nonce portion 
      * Note that we are unable to determine with 100% certainty
      * what nonce was originally chosen due to only the x coordinate
-     * being stored. We can sometimes determing which was correct, but
+     * being stored. We can sometimes determine which was correct, but
      * may have to return a second possibility.
      */
 
@@ -424,32 +425,24 @@ int secp256k1_aggsig_subtract_partial_signature(
     /* Now try neg (Rr = -R-Rs) */
     secp256k1_gej_add_ge(&nonceresult_gej_neg, &noncesum_gej_neg, &noncepartial_ge_neg);
     
-    printf("Result\n");
     if (secp256k1_gej_has_quad_y_var(&nonceresult_gej)) {
-        printf("Positive has quad y var\n");
         pos_version_has_quad = 1;
     }
     if (secp256k1_gej_has_quad_y_var(&nonceresult_gej_neg)) {
-        printf("Negative has quad y var\n");
         neg_version_has_quad = 1;
     }
     if (pos_version_has_quad && !neg_version_has_quad) {
-        printf("Pos only\n");
         secp256k1_ge_set_gej(&final, &nonceresult_gej);
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result, &final.x);
-        printf("End Result\n");
         return 1;
     } else if (!pos_version_has_quad && neg_version_has_quad) {
-        printf("Neg only\n");
         secp256k1_ge_set_gej(&final, &nonceresult_gej_neg);
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result, &final.x);
-        printf("End Result\n");
         return 1;
     } else {
-        printf("Both have quad y\n");
-        /* if both, now what? */
+        /* if both, we need to return both possibilities */
         secp256k1_ge_set_gej(&final, &nonceresult_gej);
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result, &final.x);
@@ -457,7 +450,6 @@ int secp256k1_aggsig_subtract_partial_signature(
         secp256k1_ge_set_gej(&final, &nonceresult_gej_neg);
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result_alt, &final.x);
-        printf("End Result\n");
         return 2;
     } 
 

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -376,7 +376,7 @@ int secp256k1_aggsig_subtract_partial_signature(
     ARG_CHECK(partial64 != NULL);
     (void) ctx;
 
-    /* Scalar portion */
+    /* Scalar portion, straightforward scalar subtraction */
     secp256k1_scalar_set_b32(&tmp, sig64 + 32, &overflow);
     if (overflow) {
         secp256k1_scalar_clear(&tmp);
@@ -407,8 +407,12 @@ int secp256k1_aggsig_subtract_partial_signature(
     if (!secp256k1_fe_set_b32(&noncesum_fe, sig64)) {
         return 0;
     }
+
+    /* initialize nonce sum with y value that is a quadratic residue */
     secp256k1_ge_set_xquad(&noncesum_ge, &noncesum_fe);
     secp256k1_gej_set_ge(&noncesum_gej, &noncesum_ge);
+
+    /* also initialize negated version -R */
     secp256k1_ge_neg(&noncesum_ge_neg, &noncesum_ge);
     secp256k1_gej_set_ge(&noncesum_gej_neg, &noncesum_ge_neg);
 
@@ -416,6 +420,9 @@ int secp256k1_aggsig_subtract_partial_signature(
     if (!secp256k1_fe_set_b32(&noncepartial_fe, partial64)) {
         return 0;
     }
+
+    /* Initialize negated version of partial sum, which we're going
+    to subtract from the nonce total */
     secp256k1_ge_set_xquad(&noncepartial_ge, &noncepartial_fe);
     secp256k1_ge_neg(&noncepartial_ge_neg, &noncepartial_ge);
 
@@ -428,6 +435,9 @@ int secp256k1_aggsig_subtract_partial_signature(
     pos_version_has_quad = secp256k1_gej_has_quad_y_var(&nonceresult_gej);
     neg_version_has_quad = secp256k1_gej_has_quad_y_var(&nonceresult_gej_neg);
 
+    /* If ONLY the positive 'version' of Rr (=R-Rs) or only the
+       negative version of Rr (=-R-Rs) results in a QR, then we know
+       for certain what the original x value was */
     if (pos_version_has_quad && !neg_version_has_quad) {
         secp256k1_ge_set_gej(&final, &nonceresult_gej);
         secp256k1_fe_normalize_var(&final.x);
@@ -438,8 +448,10 @@ int secp256k1_aggsig_subtract_partial_signature(
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result, &final.x);
         return 1;
-    } else {
-        /* if both, we need to return both possibilities */
+    } else if (pos_version_has_quad && neg_version_has_quad) {
+        /* if both versions result in a QR, it could have been either,
+        so we need to return both possibilities and indicate the user 
+        needs to potentially check a second value */
         secp256k1_ge_set_gej(&final, &nonceresult_gej);
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result, &final.x);
@@ -448,6 +460,13 @@ int secp256k1_aggsig_subtract_partial_signature(
         secp256k1_fe_normalize_var(&final.x);
         secp256k1_fe_get_b32(result_alt, &final.x);
         return 2;
+    } else {
+        /* if neither result in a QR, then the signature is invalid according
+        to our construction. Note this should never happen with signatures constructed
+        via this particular API, and there's a chance that signatures using a different
+        convention for selecting y coordinates could still return a valid but 'incorrect' 
+        value. */
+        return -1;
     } 
 }
 

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -346,6 +346,124 @@ int secp256k1_aggsig_partial_sign(const secp256k1_context* ctx, secp256k1_aggsig
     return 1;
 }
 
+int secp256k1_aggsig_subtract_partial_signature(
+    const secp256k1_context* ctx,
+    unsigned char* result,
+    unsigned char* result_alt,
+    const unsigned char *sig64,
+    const unsigned char *partial64
+) {
+    secp256k1_scalar tmp, tmp2;
+    secp256k1_fe noncesum_fe;
+    secp256k1_ge noncesum_ge;
+    secp256k1_gej noncesum_gej;
+    secp256k1_ge noncesum_ge_neg;
+    secp256k1_gej noncesum_gej_neg;
+    secp256k1_fe noncepartial_fe;
+    secp256k1_ge noncepartial_ge;
+    secp256k1_ge noncepartial_ge_neg;
+    secp256k1_gej nonceresult_gej;
+    secp256k1_gej nonceresult_gej_neg;
+    secp256k1_ge final;
+    int overflow;
+    int neg_version_has_quad = 0;
+    int pos_version_has_quad = 0;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(result != NULL);
+    ARG_CHECK(sig64 != NULL);
+    ARG_CHECK(partial64 != NULL);
+    (void) ctx;
+
+    /* Scalar portion */
+    secp256k1_scalar_set_b32(&tmp, sig64 + 32, &overflow);
+    if (overflow) {
+        secp256k1_scalar_clear(&tmp);
+        return 0;
+    }
+    secp256k1_scalar_set_b32(&tmp2, partial64 + 32, &overflow);
+    if (overflow) {
+        secp256k1_scalar_clear(&tmp);
+        secp256k1_scalar_clear(&tmp2);
+        return 0;
+    }
+    secp256k1_scalar_negate(&tmp2, &tmp2);
+    secp256k1_scalar_add(&tmp, &tmp, &tmp2);
+
+    secp256k1_scalar_get_b32(result + 32, &tmp);
+    secp256k1_scalar_get_b32(result_alt + 32, &tmp);
+    secp256k1_scalar_clear(&tmp);
+    secp256k1_scalar_clear(&tmp2);
+
+    /* nonce portion 
+     * Note that we are unable to determine with 100% certainty
+     * what nonce was originally chosen due to only the x coordinate
+     * being stored. We can sometimes determing which was correct, but
+     * may have to return a second possibility.
+     */
+
+    /* Parse nonce sum total and negated version (R, -R) */
+    if (!secp256k1_fe_set_b32(&noncesum_fe, sig64)) {
+        return 0;
+    }
+    secp256k1_ge_set_xquad(&noncesum_ge, &noncesum_fe);
+    secp256k1_gej_set_ge(&noncesum_gej, &noncesum_ge);
+    secp256k1_ge_neg(&noncesum_ge_neg, &noncesum_ge);
+    secp256k1_gej_set_ge(&noncesum_gej_neg, &noncesum_ge_neg);
+
+    /* Parse provided partial-sig nonce and negate */
+    if (!secp256k1_fe_set_b32(&noncepartial_fe, partial64)) {
+        return 0;
+    }
+    secp256k1_ge_set_xquad(&noncepartial_ge, &noncepartial_fe);
+    secp256k1_ge_neg(&noncepartial_ge_neg, &noncepartial_ge);
+
+    /* Try positive (Rr = R-Rs) */
+    secp256k1_gej_add_ge(&nonceresult_gej, &noncesum_gej, &noncepartial_ge_neg);
+
+    /* Now try neg (Rr = -R-Rs) */
+    secp256k1_gej_add_ge(&nonceresult_gej_neg, &noncesum_gej_neg, &noncepartial_ge_neg);
+    
+    printf("Result\n");
+    if (secp256k1_gej_has_quad_y_var(&nonceresult_gej)) {
+        printf("Positive has quad y var\n");
+        pos_version_has_quad = 1;
+    }
+    if (secp256k1_gej_has_quad_y_var(&nonceresult_gej_neg)) {
+        printf("Negative has quad y var\n");
+        neg_version_has_quad = 1;
+    }
+    if (pos_version_has_quad && !neg_version_has_quad) {
+        printf("Pos only\n");
+        secp256k1_ge_set_gej(&final, &nonceresult_gej);
+        secp256k1_fe_normalize_var(&final.x);
+        secp256k1_fe_get_b32(result, &final.x);
+        printf("End Result\n");
+        return 1;
+    } else if (!pos_version_has_quad && neg_version_has_quad) {
+        printf("Neg only\n");
+        secp256k1_ge_set_gej(&final, &nonceresult_gej_neg);
+        secp256k1_fe_normalize_var(&final.x);
+        secp256k1_fe_get_b32(result, &final.x);
+        printf("End Result\n");
+        return 1;
+    } else {
+        printf("Both have quad y\n");
+        /* if both, now what? */
+        secp256k1_ge_set_gej(&final, &nonceresult_gej);
+        secp256k1_fe_normalize_var(&final.x);
+        secp256k1_fe_get_b32(result, &final.x);
+
+        secp256k1_ge_set_gej(&final, &nonceresult_gej_neg);
+        secp256k1_fe_normalize_var(&final.x);
+        secp256k1_fe_get_b32(result_alt, &final.x);
+        printf("End Result\n");
+        return 2;
+    } 
+
+    return 0;
+}
+
 int secp256k1_aggsig_combine_signatures(const secp256k1_context* ctx, secp256k1_aggsig_context* aggctx, unsigned char *sig64, const secp256k1_aggsig_partial_signature *partial, size_t n_sigs) {
     size_t i;
     secp256k1_scalar s;

--- a/src/modules/aggsig/main_impl.h
+++ b/src/modules/aggsig/main_impl.h
@@ -425,12 +425,9 @@ int secp256k1_aggsig_subtract_partial_signature(
     /* Now try neg (Rr = -R-Rs) */
     secp256k1_gej_add_ge(&nonceresult_gej_neg, &noncesum_gej_neg, &noncepartial_ge_neg);
     
-    if (secp256k1_gej_has_quad_y_var(&nonceresult_gej)) {
-        pos_version_has_quad = 1;
-    }
-    if (secp256k1_gej_has_quad_y_var(&nonceresult_gej_neg)) {
-        neg_version_has_quad = 1;
-    }
+    pos_version_has_quad = secp256k1_gej_has_quad_y_var(&nonceresult_gej);
+    neg_version_has_quad = secp256k1_gej_has_quad_y_var(&nonceresult_gej_neg);
+
     if (pos_version_has_quad && !neg_version_has_quad) {
         secp256k1_ge_set_gej(&final, &nonceresult_gej);
         secp256k1_fe_normalize_var(&final.x);
@@ -452,8 +449,6 @@ int secp256k1_aggsig_subtract_partial_signature(
         secp256k1_fe_get_b32(result_alt, &final.x);
         return 2;
     } 
-
-    return 0;
 }
 
 int secp256k1_aggsig_combine_signatures(const secp256k1_context* ctx, secp256k1_aggsig_context* aggctx, unsigned char *sig64, const secp256k1_aggsig_partial_signature *partial, size_t n_sigs) {

--- a/src/modules/aggsig/tests_impl.h
+++ b/src/modules/aggsig/tests_impl.h
@@ -274,46 +274,28 @@ void test_aggsig_api(void) {
         sub_return_val = secp256k1_aggsig_subtract_partial_signature(none, sub_result, sub_result_alt, combined_sig, sigs[0]);
         CHECK(sub_return_val);
 
+        /* If there's only one possible result, it should be the only one that needs to be tested */
         if (sub_return_val == 1) {
             for (j = 0; j < 64; j++){
                 CHECK(sub_result[j] == sigs[1][j]);
-                printf("%0x,", sub_result[j]);
             }
-            printf("\n");
-            for (j = 0; j < 64; j++){
-                printf("%0x,", sigs[1][j]);
-            }
-            printf("\n\n");
         }
 
+        /* if there are two possible results, both potentially need to be checked */
         if (sub_return_val == 2) {
             sub_check = 1;
-            printf("First possible sig: \n");
             for (j = 0; j < 64; j++){
                 if (sub_result[j] != sigs[1][j]) {
                     sub_check = 0;
                 }
-                printf("%0x,", sub_result[j]);
             }
-            printf("\n");
-            for (j = 0; j < 64; j++){
-                printf("%0x,", sigs[1][j]);
-            }
-            printf("\n\n");
             if (!sub_check) {
                 sub_check = 1;
-                printf("Second possible sig: \n");
                 for (j = 0; j < 64; j++){
                     if (sub_result_alt[j] != sigs[1][j]) {
                         sub_check = 0;
                     }
-                    printf("%0x,", sub_result_alt[j]);
                 }
-                printf("\n");
-                for (j = 0; j < 64; j++){
-                    printf("%0x,", sigs[1][j]);
-                }
-                printf("\n\n");
             }
             CHECK(sub_check);
         }

--- a/src/tests.c
+++ b/src/tests.c
@@ -5279,11 +5279,111 @@ int main(int argc, char **argv) {
         CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? run32 : NULL));
     }
 
+    run_rand_bits();
+    run_rand_int();
+    run_util_tests();
+
+    run_sha256_tests();
+    run_hmac_sha256_tests();
+    run_rfc6979_hmac_sha256_tests();
+
+#ifndef USE_NUM_NONE
+    /* num tests */
+    run_num_smalltests();
+#endif
+
+    /* scalar tests */
+    run_scalar_tests();
+
+    /* field tests */
+    run_field_inv();
+    run_field_inv_var();
+    run_field_inv_all_var();
+    run_field_misc();
+    run_field_convert();
+    run_sqr();
+    run_sqrt();
+
+    /* group tests */
+    run_ge();
+    run_group_decompress();
+
+    /* ecmult tests */
+    run_wnaf();
+    run_point_times_order();
+    run_ecmult_chain();
+    run_ecmult_constants();
+    run_ecmult_gen_blind();
+    run_ecmult_const_tests();
+    run_ecmult_multi_tests();
+    run_ec_combine();
+
+    /* endomorphism tests */
+#ifdef USE_ENDOMORPHISM
+    run_endomorphism_tests();
+#endif
+
+    /* EC point parser test */
+    run_ec_pubkey_parse_test();
+
+    /* EC key edge cases */
+    run_eckey_edge_case_test();
+
+#ifdef ENABLE_MODULE_ECDH
+    /* ecdh tests */
+    run_ecdh_tests();
+#endif
+
+#ifdef ENABLE_MODULE_SCHNORRSIG
+    /* Schnorrsig tests */
+    run_schnorrsig_tests();
+#endif
+
+    /* ecdsa tests */
+    run_random_pubkeys();
+    run_ecdsa_der_parse();
+    run_ecdsa_sign_verify();
+    run_ecdsa_end_to_end();
+    run_ecdsa_edge_cases();
+#ifdef ENABLE_OPENSSL_TESTS
+    run_ecdsa_openssl();
+#endif
+
+#ifdef ENABLE_MODULE_RECOVERY
+    /* ECDSA pubkey recovery tests */
+    run_recovery_tests();
+#endif
+
+#ifdef ENABLE_MODULE_GENERATOR
+    run_generator_tests();
+#endif
+
+#ifdef ENABLE_MODULE_RANGEPROOF
+    run_rangeproof_tests();
+#endif
+
+#ifdef ENABLE_MODULE_BULLETPROOF
+    run_bulletproofs_tests();
+#endif
+
+#ifdef ENABLE_MODULE_COMMITMENT
+    run_commitment_tests();
+#endif
+
 #ifdef ENABLE_MODULE_AGGSIG
     run_aggsig_tests();
 #endif
 
-   secp256k1_rand256(run32);
+#ifdef ENABLE_MODULE_WHITELIST
+    /* Key whitelisting tests */
+    run_whitelist_tests();
+#endif
+
+#ifdef ENABLE_MODULE_SURJECTIONPROOF
+    run_surjection_tests();
+#endif
+
+    secp256k1_rand256(run32);
     printf("random run = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", run32[0], run32[1], run32[2], run32[3], run32[4], run32[5], run32[6], run32[7], run32[8], run32[9], run32[10], run32[11], run32[12], run32[13], run32[14], run32[15]);
 
     /* shutdown */

--- a/src/tests.c
+++ b/src/tests.c
@@ -5279,111 +5279,11 @@ int main(int argc, char **argv) {
         CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? run32 : NULL));
     }
 
-    run_rand_bits();
-    run_rand_int();
-    run_util_tests();
-
-    run_sha256_tests();
-    run_hmac_sha256_tests();
-    run_rfc6979_hmac_sha256_tests();
-
-#ifndef USE_NUM_NONE
-    /* num tests */
-    run_num_smalltests();
-#endif
-
-    /* scalar tests */
-    run_scalar_tests();
-
-    /* field tests */
-    run_field_inv();
-    run_field_inv_var();
-    run_field_inv_all_var();
-    run_field_misc();
-    run_field_convert();
-    run_sqr();
-    run_sqrt();
-
-    /* group tests */
-    run_ge();
-    run_group_decompress();
-
-    /* ecmult tests */
-    run_wnaf();
-    run_point_times_order();
-    run_ecmult_chain();
-    run_ecmult_constants();
-    run_ecmult_gen_blind();
-    run_ecmult_const_tests();
-    run_ecmult_multi_tests();
-    run_ec_combine();
-
-    /* endomorphism tests */
-#ifdef USE_ENDOMORPHISM
-    run_endomorphism_tests();
-#endif
-
-    /* EC point parser test */
-    run_ec_pubkey_parse_test();
-
-    /* EC key edge cases */
-    run_eckey_edge_case_test();
-
-#ifdef ENABLE_MODULE_ECDH
-    /* ecdh tests */
-    run_ecdh_tests();
-#endif
-
-#ifdef ENABLE_MODULE_SCHNORRSIG
-    /* Schnorrsig tests */
-    run_schnorrsig_tests();
-#endif
-
-    /* ecdsa tests */
-    run_random_pubkeys();
-    run_ecdsa_der_parse();
-    run_ecdsa_sign_verify();
-    run_ecdsa_end_to_end();
-    run_ecdsa_edge_cases();
-#ifdef ENABLE_OPENSSL_TESTS
-    run_ecdsa_openssl();
-#endif
-
-#ifdef ENABLE_MODULE_RECOVERY
-    /* ECDSA pubkey recovery tests */
-    run_recovery_tests();
-#endif
-
-#ifdef ENABLE_MODULE_GENERATOR
-    run_generator_tests();
-#endif
-
-#ifdef ENABLE_MODULE_RANGEPROOF
-    run_rangeproof_tests();
-#endif
-
-#ifdef ENABLE_MODULE_BULLETPROOF
-    run_bulletproofs_tests();
-#endif
-
-#ifdef ENABLE_MODULE_COMMITMENT
-    run_commitment_tests();
-#endif
-
 #ifdef ENABLE_MODULE_AGGSIG
     run_aggsig_tests();
 #endif
 
-#ifdef ENABLE_MODULE_WHITELIST
-    /* Key whitelisting tests */
-    run_whitelist_tests();
-#endif
-
-#ifdef ENABLE_MODULE_SURJECTIONPROOF
-    run_surjection_tests();
-#endif
-
-    secp256k1_rand256(run32);
+   secp256k1_rand256(run32);
     printf("random run = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", run32[0], run32[1], run32[2], run32[3], run32[4], run32[5], run32[6], run32[7], run32[8], run32[9], run32[10], run32[11], run32[12], run32[13], run32[14], run32[15]);
 
     /* shutdown */


### PR DESCRIPTION
WIP - Due to ambiguity around nonce y-coordinates, the current version returns two separate possible signatures in some cases (both of which much be tried for the purposes of payment proofs.

Debugging output left in for the moment, to run this test only you may want to comment or def out everything in `src/tests.c` other than `run_aggsig_tests()`